### PR TITLE
chore: re-arrange types

### DIFF
--- a/base/src/source.rs
+++ b/base/src/source.rs
@@ -266,7 +266,6 @@ impl FileSpan {
     ) -> Res<Vec<String>> {
         // println!("FilePos::loading `{}`", self.file);
         if self.pos == self.end {
-            println!("ping 1");
             return self.start.pretty(load, start_text);
         }
         let mut buf = String::with_capacity(1007);

--- a/conf/src/user.rs
+++ b/conf/src/user.rs
@@ -37,7 +37,8 @@ pub fn try_write<Out>(action: impl FnOnce(&mut Conf) -> Out) -> Res<Out> {
 /// # use conf::user::conf_path;
 /// use path_slash::PathExt;
 ///
-/// let conf_path = conf_path().unwrap().to_slash_lossy();
+/// let conf_path = conf_path().unwrap();
+/// let conf_path = conf_path.to_slash_lossy();
 /// # println!("conf_path: {}", conf_path);
 /// assert!(
 ///     conf_path.ends_with(&format!(
@@ -64,7 +65,8 @@ pub fn conf_path() -> Res<io::PathBuf> {
 /// # use conf::user::toml_path;
 /// use path_slash::PathExt;
 ///
-/// let toml_path = toml_path().unwrap().to_slash_lossy();
+/// let toml_path = toml_path().unwrap();
+/// let toml_path = toml_path.to_slash_lossy();
 /// # println!("toml_path: {}", toml_path);
 /// assert!(
 ///     toml_path.ends_with(&format!(
@@ -163,7 +165,8 @@ pub const TLA2TOOLS_FILE: &str = crate::toolchain::TLA2TOOLS_DEFAULT_NAME;
 /// # use conf::user::tla2tools_jar_path;
 /// use path_slash::PathExt;
 ///
-/// let tla2tools_jar_path = tla2tools_jar_path().unwrap().to_slash_lossy();
+/// let tla2tools_jar_path = tla2tools_jar_path().unwrap();
+/// let tla2tools_jar_path = tla2tools_jar_path.to_slash_lossy();
 /// # println!("tla2tools_jar_path: {}", tla2tools_jar_path);
 /// assert!(
 ///     tla2tools_jar_path.ends_with(&format!(

--- a/matla_api/src/lib.rs
+++ b/matla_api/src/lib.rs
@@ -28,7 +28,7 @@ pub mod prelude {
     pub use base::*;
     pub use cex;
     pub use conf;
-    pub use project;
+    pub use project::{self, tlc::outcome::*};
     pub use testing;
 
     pub use crate::{cla, mode};

--- a/matla_api/src/mode/run.rs
+++ b/matla_api/src/mode/run.rs
@@ -378,7 +378,7 @@ impl Run {
             println!("done in {}", style.bold.paint(runtime));
         }
 
-        use project::tlc::ConciseOutcome as Out;
+        use ConciseOutcome as Out;
         match concise {
             Out::Success => {
                 println!("specification is {}", style.good.paint("safe"));
@@ -448,8 +448,7 @@ impl<'a> TlcOutputHandler<'a> {
     }
 }
 impl<'a> project::tlc::Out for TlcOutputHandler<'a> {
-    fn handle_outcome(&mut self, outcome: project::tlc::RunOutcome) {
-        use project::tlc::RunOutcome;
+    fn handle_outcome(&mut self, outcome: RunOutcome) {
         match outcome {
             RunOutcome::Success => (),
             RunOutcome::Failure(_) => (),

--- a/matla_tests/src/main.rs
+++ b/matla_tests/src/main.rs
@@ -15,7 +15,7 @@ pub mod prelude {
 
     pub use base::*;
     pub use conf;
-    pub use project::{self, tlc::ConciseOutcome};
+    pub use project::{self, tlc::outcome::ConciseOutcome};
 
     pub use crate::run;
 

--- a/project/src/lib.rs
+++ b/project/src/lib.rs
@@ -10,7 +10,7 @@ pub mod prelude {
 
     pub use crate::{
         idx,
-        tlc::{self, TlcRun},
+        tlc::{self, outcome::*, TlcRun},
         FullProject, ModuleOrTop, Project, SourceProject, TargetProject,
     };
 }

--- a/project/src/tlc/outcome.rs
+++ b/project/src/tlc/outcome.rs
@@ -1,0 +1,415 @@
+//! Gathers the different kinds of outcome.
+
+prelude!();
+
+/// A failed outcome of a TLC run.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FailedOutcome {
+    /// A parse error with a description.
+    ParseError,
+    /// An assertion failure with a description.
+    AssertFailed,
+    /// Deadlock.
+    Deadlock,
+    /// Unsafe.
+    Unsafe,
+    /// Plain error.
+    Plain(String),
+}
+impl FailedOutcome {
+    /// True if [`Self::Deadlock`].
+    pub fn is_deadlock(&self) -> bool {
+        *self == Self::Deadlock
+    }
+}
+implem! {
+    for FailedOutcome {
+        Display {
+            |&self, fmt| {
+                match self {
+                    Self::ParseError => "parse error".fmt(fmt),
+                    Self::AssertFailed => "assertion failure".fmt(fmt),
+                    Self::Deadlock => "deadlock".fmt(fmt),
+                    Self::Unsafe => "unsafe".fmt(fmt),
+                    Self::Plain(s) => write!(fmt, "<{}>", s),
+                }
+            }
+        }
+    }
+}
+
+/// Outcome of a TLC run.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RunOutcome {
+    /// Success.
+    Success,
+    /// Failure.
+    Failure(FailedOutcome),
+}
+impl RunOutcome {
+    /// True if deadlock failure.
+    pub fn is_deadlock(&self) -> bool {
+        *self == Self::Failure(FailedOutcome::Deadlock)
+    }
+
+    /// Turns itself into a failure.
+    pub fn into_failure(self) -> Res<FailedOutcome> {
+        match self {
+            Self::Success => bail!("expected run to fail but got a successful outcome"),
+            Self::Failure(outcome) => Ok(outcome),
+        }
+    }
+
+    /// Map over failures, if any.
+    pub fn map_failure<Out>(&self, action: impl FnOnce(&FailedOutcome) -> Out) -> Option<Out> {
+        match self {
+            Self::Success => None,
+            Self::Failure(f) => Some(action(f)),
+        }
+    }
+
+    /// Updates itself with a new outcome.
+    ///
+    /// If `self` is [`Self::Success`], replaces itself by `that`. Otherwise, does nothing.
+    pub fn update(&mut self, that: &Self) {
+        match self {
+            Self::Success => {
+                *self = that.clone();
+            }
+            Self::Failure(_) => (),
+        }
+    }
+}
+implem! {
+    for RunOutcome {
+        Display {
+            |&self, fmt| match self {
+                Self::Success => "success".fmt(fmt),
+                Self::Failure(failed) => failed.fmt(fmt),
+            }
+        }
+        From<FailedOutcome> {
+            |failure| Self::Failure(failure)
+        }
+    }
+}
+
+/// Outcome of a TLC process: a code and an exit status.
+#[derive(Debug, Clone)]
+pub struct ProcessOutcome {
+    /// Exit code.
+    pub code: i32,
+    /// TLC exit status.
+    pub status: Option<tlc::code::Exit>,
+}
+impl ProcessOutcome {
+    /// Constructor.
+    pub fn new(code: i32) -> Res<Self> {
+        let status = tlc::code::Exit::from_code(code, &tlc::msg::Elms::EMPTY)?;
+        Ok(Self { code, status })
+    }
+}
+implem! {
+    for ProcessOutcome {
+        Display {
+            |&self, fmt| {
+                if let Some(status) = self.status.as_ref() {
+                    write!(fmt, "{} ({})", status, self.code)
+                } else {
+                    write!(fmt, "unknown TLC exit code {}", self.code)
+                }
+            }
+        }
+    }
+}
+
+/// Outcome of a run, includes statistics and errors.
+#[derive(Debug, Clone)]
+pub struct Outcome {
+    /// Process outcome.
+    pub process: ProcessOutcome,
+    /// Run outcome.
+    pub run: Option<RunOutcome>,
+    /// Runtime.
+    pub runtime: chrono::Duration,
+    /// Outcome.
+    pub errors: Vec<tlc::err::TlcError>,
+    /// Start time.
+    pub start_time: chrono::DateTime<chrono::Utc>,
+}
+impl Outcome {
+    /// Constructor.
+    pub fn new(
+        process: ProcessOutcome,
+        run: Option<RunOutcome>,
+        runtime: chrono::Duration,
+        start_time: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        Self {
+            process,
+            run,
+            runtime,
+            start_time,
+            errors: vec![],
+        }
+    }
+
+    /// Produces a concise outcome for the final report.
+    pub fn to_concise(&self) -> ConciseOutcome {
+        use tlc::code::Exit;
+        match (&self.run, &self.process.status) {
+            (Some(RunOutcome::Success), _) | (None, Some(Exit::Success)) => ConciseOutcome::Success,
+
+            (Some(RunOutcome::Failure(FailedOutcome::Unsafe)), _)
+            | (Some(RunOutcome::Failure(FailedOutcome::Deadlock)), _)
+            | (None, Some(Exit::Violation(_))) => ConciseOutcome::Unsafe,
+
+            (Some(RunOutcome::Failure(FailedOutcome::ParseError)), _)
+            | (None, Some(Exit::Failure(_))) => ConciseOutcome::IllDefined,
+
+            (Some(RunOutcome::Failure(FailedOutcome::AssertFailed)), _) => {
+                ConciseOutcome::AssertFailed
+            }
+            (Some(RunOutcome::Failure(FailedOutcome::Plain(err))), _) => {
+                ConciseOutcome::Error(Some(err))
+            }
+            (None, Some(Exit::Error(_) | Exit::PlainError)) => ConciseOutcome::Error(None),
+
+            (None, None) => ConciseOutcome::Unknown,
+        }
+    }
+}
+implem! {
+    for Outcome {
+        Deref<Target = Vec<tlc::err::TlcError>> {
+            |&self| &self.errors,
+            |&mut self| &mut self.errors,
+        }
+    }
+}
+
+/// Concise version of a run outcome.
+///
+/// Corresponds to the final result reported to the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConciseOutcome<'msg> {
+    Success,
+    Unsafe,
+    IllDefined,
+    Error(Option<&'msg str>),
+    AssertFailed,
+    Unknown,
+}
+implem! {
+    impl('msg) for ConciseOutcome<'msg> {
+        Display { |&self, fmt| match self {
+            Self::Success => "success".fmt(fmt),
+            Self::Unsafe => "unsafe".fmt(fmt),
+            Self::IllDefined => "ill-defined".fmt(fmt),
+            Self::Error(None) => "error".fmt(fmt),
+            Self::Error(Some(msg)) => write!(fmt, "error[{}]", msg),
+            Self::AssertFailed => "assert failed".fmt(fmt),
+            Self::Unknown => "<unknown>".fmt(fmt),
+        } }
+    }
+}
+impl<'msg> ConciseOutcome<'msg> {
+    /// Description.
+    pub fn desc(&self) -> String {
+        match self {
+            Self::Error(Some(msg)) => format!("error: {}", msg),
+            _ => conf::exit_code::desc(self.to_exit_code())
+                .expect("[fatal] exit codes and outcomes are desync-ed")
+                .into(),
+        }
+    }
+
+    /// Fails if `self` and `reference` are different, presenting the latter as expected.
+    pub fn expecting(self, reference: Self) -> Res<()> {
+        if self == reference {
+            Ok(())
+        } else {
+            bail!(
+                "expected `{}` outcome, got `{}`",
+                reference.desc(),
+                self.desc()
+            )
+        }
+    }
+
+    /// True on [`Self::Success`].
+    pub fn is_success(self) -> bool {
+        self == Self::Success
+    }
+    /// True on [`Self::Unsafe`].
+    pub fn is_unsafe(self) -> bool {
+        self == Self::Unsafe
+    }
+    /// True on [`Self::IllDefined`].
+    pub fn is_ill_defined(self) -> bool {
+        self == Self::IllDefined
+    }
+    /// True on [`Self::Error`].
+    pub fn is_error(self) -> bool {
+        if let Self::Error(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+    /// True on [`Self::AssertFailed`].
+    pub fn is_assert_failed(self) -> bool {
+        self == Self::AssertFailed
+    }
+    /// True on [`Self::Unknown`].
+    pub fn is_unknown(self) -> bool {
+        self == Self::Unknown
+    }
+
+    /// Matla exit code associated with this outcome.
+    pub fn to_exit_code(self) -> i32 {
+        use conf::exit_code::*;
+        match self {
+            Self::Success => SAFE,
+            Self::Unsafe => UNSAFE,
+            Self::IllDefined => ILL_DEFINED,
+            Self::Error(_) => ERROR,
+            Self::AssertFailed => ASSERT_FAILED,
+            Self::Unknown => UNKNOWN,
+        }
+    }
+    /// Constructor from an exit code, mostly used for internal tests.
+    pub fn from_exit_code(code: i32) -> Res<Self> {
+        use conf::exit_code::*;
+        let slf = if code == SAFE {
+            Self::Success
+        } else if code == UNSAFE {
+            Self::Unsafe
+        } else if code == ILL_DEFINED {
+            Self::IllDefined
+        } else if code == ERROR {
+            Self::Error(None)
+        } else if code == ASSERT_FAILED {
+            Self::AssertFailed
+        } else if code == UNKNOWN {
+            Self::Unknown
+        } else {
+            bail!(
+                "matla exit code `{}` does not exist and has no semantics",
+                code
+            )
+        };
+        Ok(slf)
+    }
+}
+
+/// Variants of mode finalization.
+#[derive(Debug, Clone)]
+pub enum ModeOutcomeKind {
+    Unknown,
+    /// Nothing failed.
+    Success {
+        safe: bool,
+    },
+    /// Something caused a problem.
+    Problem {
+        outcome: FailedOutcome,
+        reported: bool,
+    },
+    /// A counterexample.
+    Cex(cex::Cex),
+}
+impl ModeOutcomeKind {
+    /// CEX variant constructor.
+    pub fn cex(cex: impl Into<cex::Cex>) -> Self {
+        Self::Cex(cex.into())
+    }
+
+    /// Triggers an action on an unsafe outcome.
+    pub fn map_unsafe<Out>(&self, action: impl FnOnce() -> Out) -> Option<Out> {
+        match self {
+            Self::Success { safe: false } => Some(action()),
+            Self::Success { safe: true } | Self::Cex(_) | Self::Problem { .. } | Self::Unknown => {
+                None
+            }
+        }
+    }
+    /// Map over a problem, if any.
+    pub fn map_problem<Out>(
+        &self,
+        action: impl FnOnce(&FailedOutcome, bool) -> Out,
+    ) -> Option<Out> {
+        match self {
+            Self::Success { .. } | Self::Cex(_) | Self::Unknown => None,
+            Self::Problem { outcome, reported } => Some(action(outcome, *reported)),
+        }
+    }
+
+    /// Text description of an outcome kind.
+    pub fn desc(&self) -> &'static str {
+        match self {
+            Self::Success { .. } => "success",
+            Self::Problem { .. } => "problem",
+            Self::Unknown => "unknown",
+            Self::Cex(_) => "cex",
+        }
+    }
+
+    /// Destructs a CEX, error if `self`'s not a [`Self::Cex`].
+    pub fn destruct_cex(self) -> Res<cex::Cex> {
+        match self {
+            Self::Cex(cex) => Ok(cex),
+            kind => bail!(
+                "expected `ModeOutcomeKind::Cex`, got `{}` variant",
+                kind.desc(),
+            ),
+        }
+    }
+}
+
+/// Outcome of a mode finalization.
+#[derive(Debug, Clone)]
+pub struct ModeOutcome {
+    pub kind: ModeOutcomeKind,
+    pub runtime_trace: Vec<String>,
+}
+impl ModeOutcome {
+    /// Constructor.
+    pub fn new(kind: impl Into<ModeOutcomeKind>) -> Self {
+        Self {
+            kind: kind.into(),
+            runtime_trace: vec![],
+        }
+    }
+    /// Error variant constructor.
+    pub fn new_problem(outcome: FailedOutcome, reported: bool) -> Self {
+        Self::new(ModeOutcomeKind::Problem { outcome, reported })
+    }
+    /// CEX variant constructor.
+    pub fn new_cex(cex: impl Into<cex::Cex>) -> Self {
+        ModeOutcomeKind::cex(cex).into()
+    }
+    /// Success variant constructor.
+    pub fn new_success(safe: bool) -> Self {
+        ModeOutcomeKind::Success { safe }.into()
+    }
+    /// Safe variant constructor.
+    pub fn new_safe() -> Self {
+        Self::new_success(true)
+    }
+    /// Unsafe variant constructor.
+    pub fn new_unsafe() -> Self {
+        Self::new_success(false)
+    }
+}
+implem! {
+    for ModeOutcome {
+        Deref<Target = Vec<String>> {
+            |&self| &self.runtime_trace,
+            |&mut self| &mut self.runtime_trace,
+        }
+        From<ModeOutcomeKind> {
+            |kind| Self::new(kind),
+        }
+    }
+}

--- a/project/src/tlc/runtime/analysis.rs
+++ b/project/src/tlc/runtime/analysis.rs
@@ -16,6 +16,7 @@ impl IsMode for Analysis {
     fn desc(&self) -> &'static str {
         "analysis"
     }
+
     fn handle_msg(
         self,
         out: &mut impl tlc::Out,
@@ -59,6 +60,7 @@ impl IsMode for Analysis {
     }
     fn integrate(mut self, out: &mut impl tlc::Out, outcome: ModeOutcome) -> Res<Control> {
         match outcome.kind {
+            ModeOutcomeKind::Unknown => Control::keep(self).ok(),
             ModeOutcomeKind::Success { safe } => {
                 if !safe {
                     self.safe = false

--- a/project/src/tlc/runtime/control.rs
+++ b/project/src/tlc/runtime/control.rs
@@ -1,22 +1,38 @@
-//! Type used by modes to control the runtime.
+//! Type used by modes to control the [`Runtime`][tlc::runtime].
+//!
+//! When handling a message, modes issue a [`Control`] to let the runtime know what it must do.
 
 use super::*;
 
+/// Controls the [`Runtime`], issued by modes when asked to deal with a message.
+///
+/// Note that the mode takes ownership of itself when dealing with a message. This is because, in
+/// general, the mode might replace itself with a new one.
 #[derive(Debug, Clone)]
 pub enum Control {
+    /// Tells the runtime that the mode ignores this message.
+    ///
+    /// The mode stored is the original mode that was queried.
     Ignored(TlcMode),
+    /// Replaces the current mode with another one, *i.e.* the active mode changes.
     Replace(TlcMode),
+    /// Keeps the current mode and optionally activate a sub-mode.
     Keep(TlcMode, Option<TlcMode>),
+    /// Done, with an outcome.
     Finalize(ModeOutcome),
 }
 impl Control {
-    /// Ignored message constructor.
+    /// Ignore-mode message constructor.
     pub fn ignored(out: impl Into<TlcMode>) -> Self {
         Self::Ignored(out.into())
     }
     /// Finalization constructor.
     pub fn finalize(out: impl Into<ModeOutcome>) -> Self {
         Self::Finalize(out.into())
+    }
+    /// Normal finalization (no error).
+    pub fn done(safe: bool) -> Self {
+        Self::finalize(ModeOutcome::new_success(safe))
     }
     /// Mode replacement constructor.
     pub fn replace(mode: impl Into<TlcMode>) -> Self {

--- a/project/src/tlc/runtime/error.rs
+++ b/project/src/tlc/runtime/error.rs
@@ -55,6 +55,7 @@ impl IsMode for Error {
     fn desc(&self) -> &'static str {
         "error"
     }
+
     fn handle_error(
         mut self,
         _out: &mut impl tlc::Out,
@@ -97,6 +98,7 @@ impl IsMode for Error {
     }
     fn integrate(mut self, _out: &mut impl tlc::Out, outcome: ModeOutcome) -> Res<Control> {
         match outcome.kind {
+            ModeOutcomeKind::Unknown => Control::keep(self).ok(),
             ModeOutcomeKind::Success { .. } => Control::keep(self).ok(),
             ModeOutcomeKind::Cex(cex) => {
                 if self.trace.is_some() {

--- a/project/src/tlc/runtime/warmup.rs
+++ b/project/src/tlc/runtime/warmup.rs
@@ -30,4 +30,24 @@ impl IsMode for WarmUp {
             _ => Control::ignored(self).ok_some(),
         }
     }
+    fn handle_error(
+        self,
+        out: &mut impl tlc::Out,
+        msg: &tlc::msg::Msg,
+        err: &code::Err,
+        reported: bool,
+    ) -> Res<Option<Control>> {
+        let reported = if !reported {
+            match err.clone().into_tlc_error(msg.subs.clone()) {
+                Ok(err) => {
+                    out.handle_error(err)?;
+                    true
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+        IsMode::handle_error(self, out, msg, err, reported)
+    }
 }

--- a/testing/src/integration.rs
+++ b/testing/src/integration.rs
@@ -254,7 +254,7 @@ impl Test {
         let tlc = project.run_tlc_async(&mut tlc_out)?;
 
         let outcome = tlc.run()?;
-        let project::tlc::ProcessOutcome { code, status } = outcome.process;
+        let ProcessOutcome { code, status } = outcome.process;
         let expected = self.conf.expected().to_exit_code().code();
 
         if status.as_ref().map(|c| c.code()) == Some(expected) {
@@ -679,7 +679,7 @@ pub struct TlcOutputHandler {
     pub lines: Vec<String>,
     pub cexs: Vec<cex::Cex>,
     pub errors: Vec<project::tlc::TlcError>,
-    pub outcome: Option<tlc::RunOutcome>,
+    pub outcome: Option<RunOutcome>,
 }
 impl TlcOutputHandler {
     /// Constructor.
@@ -699,7 +699,7 @@ impl project::tlc::Out for TlcOutputHandler {
     fn handle_message(&mut self, msg: &project::tlc::msg::Msg, _log_level: log::Level) {
         self.lines.extend(msg.lines().into_iter().map(String::from))
     }
-    fn handle_outcome(&mut self, outcome: tlc::RunOutcome) {
+    fn handle_outcome(&mut self, outcome: RunOutcome) {
         self.outcome = Some(outcome)
     }
     fn handle_error(&mut self, error: impl Into<tlc::TlcError>) -> Res<()> {

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -8,7 +8,10 @@ use project::FullProject;
 pub mod prelude {
     pub use base::*;
     pub use conf;
-    pub use project::{self, tlc};
+    pub use project::{
+        self,
+        tlc::{self, outcome::*},
+    };
 
     pub use crate::{doc, err::*, integration, Filter, TestRes};
 }
@@ -78,11 +81,11 @@ pub struct Test<Kind> {
     /// Test full project.
     pub project: FullProject,
     /// Expected outcome.
-    pub expected: tlc::RunOutcome,
+    pub expected: RunOutcome,
 }
 impl<Src> Test<Src> {
     /// Constructor.
-    pub fn new(kind: Src, project: FullProject, expected: tlc::RunOutcome) -> Self {
+    pub fn new(kind: Src, project: FullProject, expected: RunOutcome) -> Self {
         Self {
             kind,
             project,


### PR DESCRIPTION
Moved thing around, minor cleanup:
- package all `*Outcome*` types to a separate module
- fixed a few doc-tests
- rmed spurious println