### PR TITLE
User feedback: separate verb level and state statistics by default

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -49,6 +49,22 @@ pub mod sync {
 pub mod time {
     pub use std::time::{Duration, Instant, SystemTime};
 
+    use crate::pretty_u64;
+
+    pub fn duration_fmt(d: std::time::Duration) -> String {
+        if let Ok(d) = chrono::Duration::from_std(d) {
+            chrono_duration_fmt(&d)
+        } else {
+            let mut s = format!("{}", pretty_u64(d.as_secs()));
+            match d.subsec_nanos() {
+                0 => (),
+                n => s = format!("{}.{:0>9}", s, n),
+            }
+            s.push_str(" seconds");
+            s
+        }
+    }
+
     pub fn chrono_duration_fmt(d: &chrono::Duration) -> String {
         let mut s = String::with_capacity(203);
 
@@ -102,6 +118,17 @@ pub mod msg {
 /// assert_eq!(pretty_usize(0), "0");
 /// ```
 pub fn pretty_usize(n: usize) -> String {
+    let mut s = n.to_string();
+    let mut pref = s.chars().count() % 3;
+
+    while s[pref..].len() > 3 {
+        s.insert(pref + 3, '_');
+        pref += 4;
+    }
+
+    s
+}
+pub fn pretty_u64(n: u64) -> String {
     let mut s = n.to_string();
     let mut pref = s.chars().count() % 3;
 

--- a/conf/src/prelude.rs
+++ b/conf/src/prelude.rs
@@ -10,7 +10,7 @@ pub use crate::{
     target::{self, Target},
     toolchain::{self, Toolchain},
     top_cla::{self, TopCla},
-    Conf, TlcCla,
+    vlog, Conf, TlcCla,
 };
 
 pub(crate) use crate::glob;

--- a/conf/src/top_cla.rs
+++ b/conf/src/top_cla.rs
@@ -40,6 +40,8 @@ pub struct TopCla {
     pub portable: bool,
     /// Log level.
     pub log_level: log::LevelFilter,
+    /// Verbosity level.
+    pub verb_level: usize,
     /// Path to the project directory.
     pub project_path: io::PathBuf,
 }
@@ -59,19 +61,34 @@ impl TopCla {
             color: false,
             portable: false,
             log_level: log::LevelFilter::Trace,
+            verb_level: 0,
             project_path: ".".into(),
         }
     }
 }
 
-/// Accesses the top-level CLAP verbosity argument.
+/// Accesses the top-level CLAP info verbosity argument.
+pub fn verb_level() -> Res<usize> {
+    try_read(|top| top.verb_level)
+}
+/// Sets the top-level CLAP verbosity argument.
+pub fn set_verb_level(verb: usize) -> Res<()> {
+    try_write(|top| top.verb_level = verb)
+}
+/// Applies some action to the top-level CLAP verbosity argument.
+pub fn verb_level_do(action: impl FnOnce(usize) -> usize) -> Res<()> {
+    try_write(|top| top.verb_level = action(top.verb_level))
+}
+
+/// Accesses the top-level CLAP log verbosity argument.
 pub fn log_level() -> Res<log::LevelFilter> {
     try_read(|top| top.log_level)
 }
-/// Sets the top-level CLAP verbosity argument.
+/// Sets the top-level CLAP log verbosity argument.
 pub fn set_log_level(level: log::LevelFilter) -> Res<()> {
     try_write(|top| top.log_level = level)
 }
+
 /// Accesses the top-level CLAP color argument.
 pub fn color() -> Res<bool> {
     try_read(|top| top.color)
@@ -80,6 +97,7 @@ pub fn color() -> Res<bool> {
 pub fn set_color(color: bool) -> Res<()> {
     try_write(|top| top.color = color)
 }
+
 /// Accesses the top-level CLAP portable argument.
 pub fn portable() -> Res<bool> {
     try_read(|top| top.portable)
@@ -88,6 +106,7 @@ pub fn portable() -> Res<bool> {
 pub fn set_portable(portable: bool) -> Res<()> {
     try_write(|top| top.portable = portable)
 }
+
 /// Accesses the top-level CLAP project path argument.
 pub fn project_path() -> Res<io::PathBuf> {
     try_read(|top| top.project_path.clone())

--- a/docs/manual/src/run/code/cex.test
+++ b/docs/manual/src/run/code/cex.test
@@ -1,4 +1,4 @@
-> matla run -w 1
+> matla run -q -w 1
 # 10
 Invariant cnt_leq_10 does not hold.
 Counterexample:

--- a/docs/manual/src/run/code/cond_comp_1.test
+++ b/docs/manual/src/run/code/cond_comp_1.test
@@ -1,4 +1,4 @@
-> matla run -w 1
+> matla run -q -w 1
 # 10
 Error: an assertion failed with "that's probably going to fail"
 

--- a/docs/manual/src/run/code/cond_comp_2.debug.test
+++ b/docs/manual/src/run/code/cond_comp_2.debug.test
@@ -1,4 +1,4 @@
-> matla run -w 1
+> matla run -q -w 1
 # 10
 Error: an assertion failed with "that's probably going to fail"
 

--- a/docs/manual/src/run/code/cond_comp_2.release.test
+++ b/docs/manual/src/run/code/cond_comp_2.release.test
@@ -1,3 +1,3 @@
-> matla run -w 1 --release
+> matla run -q -w 1 --release
 # 0
 specification is safe

--- a/docs/manual/src/run/code/ok.test
+++ b/docs/manual/src/run/code/ok.test
@@ -1,3 +1,3 @@
-> matla run
+> matla run -q
 # 0
 specification is safe

--- a/matla_api/src/lib.rs
+++ b/matla_api/src/lib.rs
@@ -27,7 +27,7 @@ pub mod prelude {
 
     pub use base::*;
     pub use cex;
-    pub use conf;
+    pub use conf::{self, vlog};
     pub use project::{self, tlc::outcome::*};
     pub use testing;
 

--- a/matla_api/src/mode/run.rs
+++ b/matla_api/src/mode/run.rs
@@ -381,27 +381,33 @@ impl Run {
         use ConciseOutcome as Out;
         match concise {
             Out::Success => {
-                println!("specification is {}", style.good.paint("safe"));
+                vlog!(result | "specification is {}", style.good.paint("safe"));
             }
             Out::Unsafe => {
-                println!("specification is {}", style.fatal.paint("unsafe"));
+                vlog!(result | "specification is {}", style.fatal.paint("unsafe"));
             }
             Out::IllDefined => {
-                println!("specification is {}", style.bad.paint("ill-defined"),);
+                vlog!(
+                    result | "specification is {}",
+                    style.bad.paint("ill-defined"),
+                );
             }
             Out::Error(None) => {
-                println!("specification caused an {}", style.fatal.paint("error"));
+                vlog!(
+                    result | "specification caused an {}",
+                    style.fatal.paint("error")
+                );
             }
             Out::Error(Some(msg)) => {
-                println!(
-                    "specification caused an {}: {}",
+                vlog!(
+                    result | "specification caused an {}: {}",
                     style.fatal.paint("error"),
                     style.bad.paint(msg)
                 );
             }
             Out::AssertFailed => {
-                println!(
-                    "specification {}",
+                vlog!(
+                    result | "specification {}",
                     style.fatal.paint("failed on an assertion")
                 );
             }

--- a/project/src/tlc/code.rs
+++ b/project/src/tlc/code.rs
@@ -573,9 +573,9 @@ code_enums! {
             TlcCheckpointRecoverStart = (2197, "[tlc msg] checkpoint recover start"),
             TlcCheckpointRecoverEnd = (2198, "[tlc msg] checkpoint recover end"),
             TlcStats = (2199, "[tlc msg] stats") {
-                generated: usize,
-                distinct: usize,
-                left: usize,
+                generated: (Int, String),
+                distinct: (Int, String),
+                left: (Int, String),
             } => |contents| {
                 let line = contents.get_1_plain_str()?;
                 tlc::parse::stats(line)
@@ -584,11 +584,11 @@ code_enums! {
             TlcStatsDfid = (2204, "[tlc msg] stats dfid"),
             TlcStatsSimu = (2210, "[tlc msg] stats simu"),
             TlcProgressStats = (2200, "[tlc msg] progress stats") {
-                generated: usize,
-                gen_spm: Option<usize>,
-                distinct: usize,
-                dist_spm: Option<usize>,
-                left: usize,
+                generated: (Int, String),
+                gen_spm: Option<(Int, String)>,
+                distinct: (Int, String),
+                dist_spm: Option<(Int, String)>,
+                left: (Int, String),
             } => |contents| {
                 let line = contents.get_1_plain_str()?;
                 tlc::parse::progress_stats(line)
@@ -704,7 +704,7 @@ code_enums! {
             TlcComputingInit = (2189, "[status] computing init"),
 
             TlcInitGenerated1 = (2190, "[status] init generated (1)") {
-                state_count: usize,
+                state_count: (Int, String),
                 end_time: chrono::NaiveDateTime,
             } => |contents| {
                 let line = contents.get_1_plain_str()?;

--- a/tests/projects/demos/conditional_compilation/type_checking_1.test
+++ b/tests/projects/demos/conditional_compilation/type_checking_1.test
@@ -1,3 +1,3 @@
-> matla run top
+> matla run -q top
 # 0
 specification is safe

--- a/tests/projects/errors/semantics_multi_1.test
+++ b/tests/projects/errors/semantics_multi_1.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: multiple problems occurred during semantic processing
 - on file `./top.tla` (top, 10:21 → 10:24)

--- a/tests/projects/errors/simple/bad_module_end_1.test
+++ b/tests/projects/errors/simple/bad_module_end_1.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: parse error on file `./top.tla`
 - expected Expression or Instance, encountered `Beginning of definition` and `==`

--- a/tests/projects/errors/simple/bad_module_start_1.test
+++ b/tests/projects/errors/simple/bad_module_start_1.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: parse error on file `./top.tla`
 - expected Identifier, encountered `----` and `---- MODULE`

--- a/tests/projects/errors/simple/bad_module_start_2.test
+++ b/tests/projects/errors/simple/bad_module_start_2.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: on file `./top.tla`
 - In `top.tla`: unexpected top-most header module name `no_top`;

--- a/tests/projects/errors/simple/bad_module_start_3.test
+++ b/tests/projects/errors/simple/bad_module_start_3.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: parse error on file `./top.tla`
 - expected ----, encountered `--` and `top`

--- a/tests/projects/errors/simple/bad_spec_1.test
+++ b/tests/projects/errors/simple/bad_spec_1.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: on file `./top.cfg`
 - The `.cfg` file provided does not specify an initial state predicate.

--- a/tests/projects/errors/simple/lexical_1.test
+++ b/tests/projects/errors/simple/lexical_1.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: lexical error on file `./top.tla` (49:24)
 - warning: TLC's lexical errors are more art than science

--- a/tests/projects/errors/simple/no_module_end.test
+++ b/tests/projects/errors/simple/no_module_end.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: parse error on file `./top.tla`
 - expected ==== or more Module body, encountered `<EOF>` and `TRUE`

--- a/tests/projects/errors/simple/no_module_start.test
+++ b/tests/projects/errors/simple/no_module_start.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: on file `./top.tla`
 - TLC-level exception `java.lang.NullPointerException`

--- a/tests/projects/safe/simple/sw0_invs.test
+++ b/tests/projects/safe/simple/sw0_invs.test
@@ -1,3 +1,3 @@
-> matla run top
+> matla run -q top
 # 0
 specification is safe

--- a/tests/projects/safe/simple/sw0_no_invs.test
+++ b/tests/projects/safe/simple/sw0_no_invs.test
@@ -1,3 +1,3 @@
-> matla run top
+> matla run -q top
 # 0
 specification is safe

--- a/tests/projects/tlc_issues/assert_exit_code.test
+++ b/tests/projects/tlc_issues/assert_exit_code.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 10
 Error: an assertion failed with "b1 is not TRUE"
 

--- a/tests/projects/tlc_issues/newline_problem_issue_732.test
+++ b/tests/projects/tlc_issues/newline_problem_issue_732.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla run -q top
 # 20
 Error: In computing next states, TLC expected a boolean expression,
 but instead found 7.

--- a/tests/projects/unsafe/simple_cexs/safety_cex_1.test
+++ b/tests/projects/unsafe/simple_cexs/safety_cex_1.test
@@ -1,4 +1,4 @@
-> matla run -w 1 top
+> matla run -q -w 1 top
 # 10
 Invariant pos_leq_10 does not hold.
 Counterexample:

--- a/tests/projects/unsafe/simple_cexs/temporal_cex_1.test
+++ b/tests/projects/unsafe/simple_cexs/temporal_cex_1.test
@@ -1,4 +1,4 @@
-> matla run top
+> matla -q run top
 # 10
 Some temporal property(ies) do not hold.
 Counterexample:


### PR DESCRIPTION
Add a notion of verb level, which is different from log level. Log level is for internal (debug) information, while verb level controls the amount of stats/feedback users get.

- revamp overall clap workflow (fewer macros)

  now easy to have flags at root-clap level and every command-clap level, if there are no clashes
- add notion of verb level
- output state statistics by default (verb level `1`)
- higher verb levels add time statistics
- clap controls verb level with `-v` and `-q`
- updated tests to run in quiet mode (no feedback except final result) to get the same output as before